### PR TITLE
sync scrape data process now caches the s3 object list

### DIFF
--- a/src/vigorish/util/regex.py
+++ b/src/vigorish/util/regex.py
@@ -74,12 +74,14 @@ PITCHFX_LOG_PATCH_LIST_FILENAME_REGEX = BBREF_BOXSCORE_PATCH_LIST_FILENAME_REGEX
 
 COMBINED_DATA_FILENAME_REGEX = re.compile(
     r"""
+    ^
     (?P<home_team>[A-Z]{3,3})
     (?P<year>\d{4,4})
     (?P<month>\d{2,2})
     (?P<day>\d{2,2})
     (?P<game_num>\d)
     _COMBINED_DATA
+    $
 """,
     re.VERBOSE,
 )


### PR DESCRIPTION
-the list of s3 objects was being retrieved multiple times, making the sync process very long
-this change reduces the execution time significantly