### PR TITLE
fix: combining multiple at bat events can result in data loss

### DIFF
--- a/src/vigorish/tasks/combine_scraped_data.py
+++ b/src/vigorish/tasks/combine_scraped_data.py
@@ -431,6 +431,10 @@ class CombineScrapedData:
             pbp_events_for_at_bat = self.get_all_pbp_events_for_at_bat(ab_id)
             first_event_this_at_bat = pbp_events_for_at_bat[0]
             final_event_this_at_bat = pbp_events_for_at_bat[-1]
+            runs_outs_result = final_event_this_at_bat["runs_outs_result"]
+            if len(pbp_events_for_at_bat) > 1:
+                all_results = [event["runs_outs_result"] for event in pbp_events_for_at_bat]
+                runs_outs_result = "".join(all_results)
             pitch_seq = final_event_this_at_bat["pitch_sequence"]
             result = self.get_total_pitches_in_sequence(pitch_seq)
             if result.failure:
@@ -529,7 +533,7 @@ class CombineScrapedData:
                 "score": final_event_this_at_bat["score"],
                 "outs_before_play": final_event_this_at_bat["outs_before_play"],
                 "runners_on_base": final_event_this_at_bat["runners_on_base"],
-                "runs_outs_result": final_event_this_at_bat["runs_outs_result"],
+                "runs_outs_result": runs_outs_result,
                 "play_description": final_event_this_at_bat["play_description"],
                 "pitch_sequence_description": pitch_sequence_description,
                 "pbp_events": self.at_bat_event_groups[ab_id],


### PR DESCRIPTION
a single run scored was being ignored:
- if an at bat contained multiple "events"
- e.g., if a wild pitched caused a runner on 3B to score and later the batter struck out
- this fix now captures the run scored which was being lost