### PR TITLE
vig sync cli command always hard crashes

### DIFF
--- a/src/vigorish/cli/vig.py
+++ b/src/vigorish/cli/vig.py
@@ -257,15 +257,15 @@ def sync(app):
 @click.argument("year", type=MlbSeason(), default=current_year)
 @click.option(
     "--file-type",
-    type=click.Choice([ft.name for ft in VigFile if ft != VigFile.ALL]),
+    type=click.Choice([str(ft) for ft in VigFile if ft != VigFile.ALL]),
     help="Type of file to sync, must provide only one value.",
     prompt=True,
 )
 @click.option(
     "--data-sets",
-    type=click.Choice(str(ds) for ds in DataSet),
+    type=click.Choice([str(ds) for ds in DataSet]),
     multiple=True,
-    default=[DataSet.ALL],
+    default=[str(DataSet.ALL)],
     show_default=True,
     help="Data set(s) to sync, multiple values can be provided.",
 )
@@ -274,8 +274,12 @@ def sync_up_to_s3(app, year, file_type, data_sets):
     """Sync files from local folder to S3 bucket."""
     file_type = VigFile.from_str(file_type)
     data_sets_int = sum(int(DataSet.from_str(ds)) for ds in data_sets)
-    sync_task = SyncScrapedDataNoPrompts(app)
-    result_dict = sync_task.execute(SyncDirection.UP_TO_S3, year, file_type, data_sets_int)
+    result_dict = SyncScrapedDataNoPrompts(app).execute(
+        sync_direction=SyncDirection.UP_TO_S3,
+        year=year,
+        file_type=file_type,
+        data_sets_int=data_sets_int,
+    )
     result = Result.Combine([result for result in result_dict.values()])
     return exit_app(app, result)
 
@@ -284,15 +288,15 @@ def sync_up_to_s3(app, year, file_type, data_sets):
 @click.argument("year", type=MlbSeason(), default=current_year)
 @click.option(
     "--file-type",
-    type=click.Choice([ft.name for ft in VigFile if ft != VigFile.ALL]),
+    type=click.Choice([str(ft) for ft in VigFile if ft != VigFile.ALL]),
     help="Type of file to sync, must provide only one value.",
     prompt=True,
 )
 @click.option(
     "--data-sets",
-    type=click.Choice(str(ds) for ds in DataSet),
+    type=click.Choice([str(ds) for ds in DataSet]),
     multiple=True,
-    default=[DataSet.ALL],
+    default=[str(DataSet.ALL)],
     show_default=True,
     help="Data set(s) to sync, multiple values can be provided.",
 )
@@ -301,8 +305,12 @@ def sync_down_to_local(app, year, file_type, data_sets):
     """Sync files from S3 bucket to local folder."""
     file_type = VigFile.from_str(file_type)
     data_sets_int = sum(int(DataSet.from_str(ds)) for ds in data_sets)
-    sync_task = SyncScrapedDataNoPrompts(app)
-    result_dict = sync_task.execute(SyncDirection.DOWN_TO_LOCAL, year, file_type, data_sets_int)
+    result_dict = SyncScrapedDataNoPrompts(app).execute(
+        sync_direction=SyncDirection.DOWN_TO_LOCAL,
+        year=year,
+        file_type=file_type,
+        data_sets_int=data_sets_int,
+    )
     result = Result.Combine([result for result in result_dict.values()])
     return exit_app(app, result)
 

--- a/src/vigorish/tasks/sync_scraped_data.py
+++ b/src/vigorish/tasks/sync_scraped_data.py
@@ -297,6 +297,6 @@ class SyncScrapedDataTask(Task):
 
     def send_file(self, sync_direction, local_path, s3_key):
         if sync_direction == SyncDirection.UP_TO_S3:
-            self.file_helper.client.upload_file(local_path, self.bucket_name, s3_key)
+            self.file_helper.get_s3_bucket().upload_file(str(local_path), s3_key)
         if sync_direction == SyncDirection.DOWN_TO_LOCAL:
-            self.file_helper.resource.Bucket(self.bucket_name).download_file(s3_key, local_path)
+            self.file_helper.get_s3_bucket().download_file(s3_key, str(local_path))


### PR DESCRIPTION
bug occurred after enums were made duck-typable

- enums that act as bit flags were not modified correctly